### PR TITLE
Fix bug with multiple HMT associations

### DIFF
--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -421,7 +421,7 @@ module PaperTrail
         # if the association is a has_many association again, then call reify_has_manys for each through_collection
         if !assoc.source_reflection.belongs_to? && through_collection.present?
           through_collection.each { |through_model| reify_has_manys(through_model,options) }
-          return
+          next
         end
 
         collection_keys = through_collection.map { |through_model| through_model.send(assoc.association_foreign_key)}

--- a/test/dummy/app/models/chapter.rb
+++ b/test/dummy/app/models/chapter.rb
@@ -2,5 +2,8 @@ class Chapter < ActiveRecord::Base
   has_many :sections, :dependent => :destroy
   has_many :paragraphs, :through => :sections
 
+  has_many :quotations, :dependent => :destroy
+  has_many :citations, :through => :quotations
+
   has_paper_trail
 end

--- a/test/dummy/app/models/citation.rb
+++ b/test/dummy/app/models/citation.rb
@@ -1,0 +1,5 @@
+class Citation < ActiveRecord::Base
+  belongs_to :quotation
+
+  has_paper_trail
+end

--- a/test/dummy/app/models/quotation.rb
+++ b/test/dummy/app/models/quotation.rb
@@ -1,0 +1,5 @@
+class Quotation < ActiveRecord::Base
+  belongs_to :chapter
+  has_many :citations, :dependent => :destroy
+  has_paper_trail
+end

--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -225,9 +225,19 @@ class SetUpTestTables < ActiveRecord::Migration
       t.integer :section_id
       t.string :name
     end
+
+    create_table :quotations, :force => true do |t|
+      t.integer :chapter_id
+    end
+
+    create_table :citations, :force => true do |t|
+      t.integer :quotation_id
+    end
   end
 
   def self.down
+    drop_table :citations
+    drop_table :quotations
     drop_table :animals
     drop_table :skippers
     drop_table :not_on_updates

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -2049,5 +2049,23 @@ class HasPaperTrailModelTransactionalTest < ActiveSupport::TestCase
         end
       end
     end
+
+    context "a chapter with one paragraph and one citation" do
+      should "reify paragraphs and citations" do
+        chapter = Chapter.create(:name => 'Chapter One')
+        section = Section.create(:name => 'Section One', :chapter => chapter)
+        paragraph = Paragraph.create(:name => 'Paragraph One', :section => section)
+        quotation = Quotation.create(:chapter => chapter)
+        citation = Citation.create(:quotation => quotation)
+        Timecop.travel 1.second.since
+        chapter.update_attributes(:name => 'Chapter One, Vers. Two')
+        assert_equal 2, chapter.versions.count
+        paragraph.destroy!
+        citation.destroy!
+        reified = chapter.versions[1].reify(:has_many => true)
+        assert_equal [paragraph], reified.sections.first.paragraphs
+        assert_equal [citation], reified.quotations.first.citations
+      end
+    end
   end
 end


### PR DESCRIPTION
When a record has multiple Has Many Through (HMT) associations,
the reify_has_many_through should process all of them. That's why
we can't `return` too early out of the loop that iterates over
associations.
